### PR TITLE
0.2.2 - Deep/Shallow copy of values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.2] - 2020-07-30
+- **[Added]** Boards can now check if a key already exist using the `exist` method.
+- **[Added]** You can specify whether a deep copy or shallow copy of an object is saved in the board using the `deep_copy` flag in the set/get methods. By default, the flag is set to true.
+- **[Added]** Additional tests to check the new board functionalities and validate end state runs completely before the machine consider it complete.
+
 ## [0.2.1] - 2020-07-09
 #### Added
 - `get_debug_info` that returns a dict that contains debugging informations

--- a/behavior_machine/board.py
+++ b/behavior_machine/board.py
@@ -1,7 +1,7 @@
 
 import threading
 import typing
-
+import copy
 
 class Board():
 
@@ -9,10 +9,63 @@ class Board():
         self._map = {}
         self._lock = threading.RLock()
 
-    def get(self, key: str) -> typing.Any:
-        with self._lock:
-            return self._map.get(key, None)
+    def get(self, key: str, deep_copy: bool = True) -> typing.Any:
+        """Get the object associated with the key from the board. If the key doesn't exist, None is returned. 
+        By default, a deep copy of the object/variable is made. You can change this by setting deep_copy = False.
 
-    def set(self, key: str, value: typing.Any) -> None:
+        Parameters
+        ----------
+        key : str
+            Key used in the set function
+        deep_copy : bool, optional
+            Whether to create a deep_copy of the object, by default True
+
+        Returns
+        -------
+        typing.Any
+            The object/variable saved with the key.
+        """
         with self._lock:
-            self._map[key] = value
+            if deep_copy:
+                return copy.deepcopy(self._map.get(key, None))
+            else:
+                return self._map.get(key, None)
+
+
+    def set(self, key: str, value: typing.Any, deep_copy: bool = True) -> None:
+        """Save the object with the given key in the board. By default, a deep copy
+        of the object is made. You can change this by setting deep_copy = False.
+        There is no check for repetitions and newer objects will replace the old objects
+        given the same key
+
+        Parameters
+        ----------
+        key : str
+            key to identify object in the board
+        value : typing.Any
+            object or variable to be saved
+        deep_copy : bool, optional
+            whether a deepcopy of the object/variable is made, by default True
+        """
+        with self._lock:
+            if deep_copy:
+                self._map[key] = copy.deepcopy(value)
+            else:
+                self._map[key] = value
+
+
+    def exist(self, key:str) -> bool:
+        """Checks whether a key already exist in the board.
+
+        Parameters
+        ----------
+        key : str
+            Key to check
+
+        Returns
+        -------
+        bool
+            True if the key exist in the board, False otherwise.
+        """
+        with self._lock:
+            return key in self._map

--- a/behavior_machine/board.py
+++ b/behavior_machine/board.py
@@ -3,6 +3,7 @@ import threading
 import typing
 import copy
 
+
 class Board():
 
     def __init__(self):
@@ -31,7 +32,6 @@ class Board():
             else:
                 return self._map.get(key, None)
 
-
     def set(self, key: str, value: typing.Any, deep_copy: bool = True) -> None:
         """Save the object with the given key in the board. By default, a deep copy
         of the object is made. You can change this by setting deep_copy = False.
@@ -52,9 +52,7 @@ class Board():
                 self._map[key] = copy.deepcopy(value)
             else:
                 self._map[key] = value
-
-
-    def exist(self, key:str) -> bool:
+    def exist(self, key: str) -> bool:
         """Checks whether a key already exist in the board.
 
         Parameters

--- a/tests/statemachine_test.py
+++ b/tests/statemachine_test.py
@@ -95,6 +95,22 @@ def test_end_case():
     assert exe.is_end()
 
 
+# This test checks if machine is completed (is_end()) 
+# only after the endState finish execution.
+def test_end_case_delay(capsys):
+    ps1 = PrintState("ps1", "Hello World")
+    class EndState(State):
+        def execute(self, board):
+            time.sleep(0.5)
+            print('completed')
+            return StateStatus.SUCCESS
+    es = EndState('endState')
+    ps1.add_transition_on_success(es)
+    exe = Machine("xe", ps1, end_state_ids=["endState"], rate=10)
+    exe.run()
+    assert exe.is_end()
+    assert capsys.readouterr().out == "Hello World\ncompleted\n"
+
 def test_machine_rate_slow():
     ps1 = PrintState("ps1", "print1")  # execute at second 0
     ps2 = PrintState("ps1", "print2")  # execute at second 2


### PR DESCRIPTION
## [0.2.2] - 2020-07-30
- **[Added]** Boards can now check if a key already exist using the `exist` method.
- **[Added]** You can specify whether a deep copy or shallow copy of an object is saved in the board using the `deep_copy` flag in the set/get methods. By default, the flag is set to true.
- **[Added]** Additional tests to check the new board functionalities and validate end state runs completely before the machine consider it complete.