### PR TITLE
Changed isAlive to is_alive.

### DIFF
--- a/behavior_machine/core.py
+++ b/behavior_machine/core.py
@@ -157,9 +157,9 @@ class State():
         bool
             Whether the current state finished, if false, it means timedout.
         """
-        if self._run_thread is not None and self._run_thread.isAlive():
+        if self._run_thread is not None and self._run_thread.is_alive():
             self._run_thread.join(timeout)
-            return not self._run_thread.isAlive()
+            return not self._run_thread.is_alive()
         return True
 
     def interrupt(self, timeout: float = None) -> bool:
@@ -341,7 +341,7 @@ class Machine(NestedState):
         self._curr_state = self._curr_state.tick(board)
 
     def is_end(self) -> bool:
-        return not self._curr_state._run_thread.isAlive() and \
+        return not self._curr_state._run_thread.is_alive() and \
             (self._curr_state._name == self._end_state_ids or self._curr_state._name in self._end_state_ids)
 
     def run(self, board: Board = None) -> None:

--- a/behavior_machine/library/parallel_state.py
+++ b/behavior_machine/library/parallel_state.py
@@ -36,7 +36,7 @@ class ParallelState(NestedState):
         self._children_complete_event.set()
         # we wait for the main thread to stop
         self._run_thread.join(timeout)
-        return not self._run_thread.isAlive()
+        return not self._run_thread.is_alive()
         # return super().interrupt(timeout=timeout)
 
     def execute(self, board: Board):

--- a/behavior_machine/library/sequential_state.py
+++ b/behavior_machine/library/sequential_state.py
@@ -51,7 +51,7 @@ class SequentialState(NestedState):
                 pass
         # wait for thread to end
         self._run_thread.join(timeout)
-        return not self._run_thread.isAlive()
+        return not self._run_thread.is_alive()
 
     def tick(self, board):
         next_state = super().tick(board)

--- a/tests/library/parallel_state_test.py
+++ b/tests/library/parallel_state_test.py
@@ -28,7 +28,7 @@ def test_parallel_state_individual(capsys):
     assert pm.wait(0.1)
     assert not pm.checkStatus(StateStatus.RUNNING)
     assert pm.checkStatus(StateStatus.SUCCESS)
-    assert not pm._run_thread.isAlive()
+    assert not pm._run_thread.is_alive()
 
 
 def test_parallel_state_in_machine(capsys):
@@ -49,7 +49,7 @@ def test_parallel_state_in_machine(capsys):
     # wait another one seconds
     assert exe.wait(2)
     assert exe.checkStatus(StateStatus.SUCCESS)
-    assert not pm._run_thread.isAlive()
+    assert not pm._run_thread.is_alive()
 
 
 def test_parallel_one_state_fails(capsys):
@@ -79,7 +79,7 @@ def test_parallel_one_state_fails(capsys):
     # wait another one seconds
     assert exe.wait(2)
     assert exe._curr_state == fes
-    assert not pm._run_thread.isAlive()
+    assert not pm._run_thread.is_alive()
 
 
 def test_exception_in_parallel_state(capsys):
@@ -103,7 +103,7 @@ def test_exception_in_parallel_state(capsys):
     assert exe.checkStatus(StateStatus.EXCEPTIION)
     assert str(exe._internal_exception) == error_text
     assert exe._exception_raised_state_name == "xe.pm.re"
-    assert not pm._run_thread.isAlive()
+    assert not pm._run_thread.is_alive()
 
 
 def test_interrupt_in_parallel_state(capsys):
@@ -120,7 +120,7 @@ def test_interrupt_in_parallel_state(capsys):
     assert exe.wait(0.2)
     assert ws.checkStatus(StateStatus.INTERRUPTED)
     assert ws2.checkStatus(StateStatus.INTERRUPTED)
-    assert not pm._run_thread.isAlive()
+    assert not pm._run_thread.is_alive()
 
 
 def test_parallel_state_performance(capsys):
@@ -137,7 +137,7 @@ def test_parallel_state_performance(capsys):
     exe.interrupt()
     duration = time.time() - start_time
     assert duration < 2  # as long as its not too slow, we are fine.
-    assert not pm._run_thread.isAlive()
+    assert not pm._run_thread.is_alive()
 
 
 def test_parallel_debug_info():

--- a/tests/library/sequential_state_test.py
+++ b/tests/library/sequential_state_test.py
@@ -83,9 +83,9 @@ def test_interruption_in_sequential_state(capsys):
     assert ws2.checkStatus(StateStatus.INTERRUPTED)
     assert ws1.checkStatus(StateStatus.SUCCESS)
     assert ps1.checkStatus(StateStatus.UNKNOWN)
-    assert not sm._run_thread.isAlive()
-    assert not ws1._run_thread.isAlive()
-    assert not ws2._run_thread.isAlive()
+    assert not sm._run_thread.is_alive()
+    assert not ws1._run_thread.is_alive()
+    assert not ws2._run_thread.is_alive()
 
 
 def test_sequential_state_success(capsys):
@@ -121,13 +121,13 @@ def test_interruption_in_machines_with_sequential_state(capsys):
     assert exe._exception_raised_state_name == ""
     assert exe._internal_exception is None
     assert exe._status == StateStatus.SUCCESS
-    assert not exe._run_thread.isAlive()
+    assert not exe._run_thread.is_alive()
     assert exe._curr_state._name == 'iss'
     assert exe.is_end()
     assert capsys.readouterr().out == ""
-    assert not sm._run_thread.isAlive()
-    assert not ws1._run_thread.isAlive()
-    assert not ws2._run_thread.isAlive()
+    assert not sm._run_thread.is_alive()
+    assert not ws1._run_thread.is_alive()
+    assert not ws2._run_thread.is_alive()
     assert sm._status == StateStatus.INTERRUPTED
     assert ws2._status == StateStatus.INTERRUPTED
     assert ws1._status == StateStatus.SUCCESS

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -40,7 +40,7 @@ def test_interrupt():
     t.interrupt()
     t.wait()
     assert t._status == StateStatus.NOT_SPECIFIED
-    assert not t._run_thread.isAlive()
+    assert not t._run_thread.is_alive()
 
 
 def test_exception_base(capsys):

--- a/tests/statemachine_test.py
+++ b/tests/statemachine_test.py
@@ -194,8 +194,8 @@ def test_machine_with_exception_in_transition(capsys):
     mac.run()
 
     assert mac._status == StateStatus.EXCEPTIION
-    assert not mac._run_thread.isAlive()
-    assert not is1._run_thread.isAlive()
+    assert not mac._run_thread.is_alive()
+    assert not is1._run_thread.is_alive()
     assert is2._run_thread is None  # Never reach is2
 
 
@@ -211,8 +211,8 @@ def test_machine_with_exception_in_transition_with_zombie_states(capsys):
     assert mac._status == StateStatus.EXCEPTIION
     # this is an interrupted, because exception happen at higher level
     assert ws1._status == StateStatus.INTERRUPTED
-    assert not mac._run_thread.isAlive()
-    assert not ws1._run_thread.isAlive()
+    assert not mac._run_thread.is_alive()
+    assert not ws1._run_thread.is_alive()
     assert is2._run_thread is None  # Never reach it
 
 


### PR DESCRIPTION
"The isAlive() method of threading.Thread has been removed. It was deprecated since Python 3.8. Use is_alive() instead. (Contributed by Dong-hee Na in bpo-37804.)"
https://docs.python.org/3/whatsnew/3.9.html