### PR TITLE
v0.3.5 - Flow in Sequential/Selector

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "autoDocstring.docstringFormat": "numpy",
+    "python.pythonPath": "venv/bin/python",
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.formatting.autopep8Args": [
+        "--max-line-length=129"
+    ],
+    "python.linting.flake8Args": [
+        "--max-line-length=129"
+    ],
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## [Unreleased]
-- **[Fixed]** race condition in `SequentialState` where the internal states are `tick()` before they are set/initialized.
+- **[Added]** `SelectorState` and `SequentialState` now has a flowout value which is from the last `succcess` state, None otherwise.
 - **[Changed]** `add_transition_on_complete` now has option to not ignore exceptions (default is always not).
+- **[Fixed]** race condition in `SequentialState` where the internal states are `tick()` before they are set/initialized.
 
 ## [0.3.4] - 2021-05-24
 - **[Added]** Added example of the visualization on first page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.5] - 2021-06-15
 - **[Added]** `SelectorState` and `SequentialState` now has a flowout value which is from the last `succcess` state, None otherwise.
 - **[Changed]** `add_transition_on_complete` now has option to not ignore exceptions (default is always not).
 - **[Fixed]** race condition in `SequentialState` where the internal states are `tick()` before they are set/initialized.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - **[Fixed]** race condition in `SequentialState` where the internal states are `tick()` before they are set/initialized.
+- **[Changed]** `add_transition_on_complete` now has option to not ignore exceptions (default is always not).
 
 ## [0.3.4] - 2021-05-24
 - **[Added]** Added example of the visualization on first page.

--- a/behavior_machine/core/state.py
+++ b/behavior_machine/core/state.py
@@ -114,7 +114,7 @@ class State():
             return False
         self.add_transition(timepassed, next_state)
 
-    def add_transition_on_complete(self, next_state: 'State') -> None:
+    def add_transition_on_complete(self, next_state: 'State', ignore_exeception: bool = False) -> None:
         """Add transition to this state where when the state finishes execution regardless of output,
         it move tos the given state.
 
@@ -122,8 +122,11 @@ class State():
         ----------
         next_state : State
             State to transition to
+        ignore_exeception: bool
+            Whether to also ignore exceptions
         """
-        self.add_transition(lambda x, y: not x._run_thread.is_alive(), next_state)
+        self.add_transition(lambda x, y: not x._run_thread.is_alive()
+                            and (ignore_exeception or not x.check_status(StateStatus.EXCEPTION)), next_state)
 
     def add_transition_on_success(self, next_state: 'State') -> None:
         """Add transition to this state where when it is succesfully, move to the given state.

--- a/behavior_machine/library/sequential_state.py
+++ b/behavior_machine/library/sequential_state.py
@@ -25,7 +25,7 @@ class SequentialState(NestedState):
             child._status = StateStatus.NOT_RUNNING
         return super().pre_execute()
 
-    def execute(self, board: Board):
+    def execute(self, board: Board) -> StateStatus:
         flow_val = self.flow_in
         # execute each children one by one in order
         for child in self._children:
@@ -45,8 +45,9 @@ class SequentialState(NestedState):
                 return StateStatus.EXCEPTION
             elif status != StateStatus.SUCCESS:
                 return status
-            # update flow_val
+            # update flow_val & set the flow out to be the current flow
             flow_val = self._curr_child.flow_out
+            self.flow_out = flow_val
         return StateStatus.SUCCESS
 
     def interrupt(self, timeout=None):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(name='behavior_machine',
-                 version='0.3.4',
+                 version='0.3.5',
                  description='An implementation of a behavior tree + hierarchical state machine hybrid.',
                  long_description=long_description,
                  long_description_content_type="text/markdown",


### PR DESCRIPTION
## [0.3.5] - 2021-06-15
- **[Added]** `SelectorState` and `SequentialState` now has a flowout value which is from the last `succcess` state, None otherwise.
- **[Changed]** `add_transition_on_complete` now has option to not ignore exceptions (default is always not).
- **[Fixed]** race condition in `SequentialState` where the internal states are `tick()` before they are set/initialized.
